### PR TITLE
Deal with case when input video contains numbers

### DIFF
--- a/src/openpose_3dpose_sandbox.py
+++ b/src/openpose_3dpose_sandbox.py
@@ -63,7 +63,7 @@ def read_openpose_json(smooth=True, *args):
 
         # get frame index from openpose 12 padding
         frame_indx = re.findall("(\d+)", file_name)
-        logger.debug("found {0} for frame {1}".format(xy, str(int(frame_indx[0]))))
+        logger.debug("found {0} for frame {1}".format(xy, str(int(frame_indx[-1]))))
 
         #body_25 support, convert body_25 output format to coco
         if len(_data)>54:
@@ -118,7 +118,7 @@ def read_openpose_json(smooth=True, *args):
             xy = _xy
 
         #add xy to frame
-        cache[int(frame_indx[0])] = xy
+        cache[int(frame_indx[-1])] = xy
 
     plt.figure(1)
     drop_curves_plot = show_anim_curves(cache, plt)
@@ -142,8 +142,8 @@ def read_openpose_json(smooth=True, *args):
     logger.info("start smoothing")
 
     # create frame blocks
-    head_frame_block = [int(re.findall("(\d+)", o)[0]) for o in json_files[:4]]
-    tail_frame_block = [int(re.findall("(\d+)", o)[0]) for o in json_files[-4:]]
+    head_frame_block = [int(re.findall("(\d+)", o)[-1]) for o in json_files[:4]]
+    tail_frame_block = [int(re.findall("(\d+)", o)[-1]) for o in json_files[-4:]]
 
     ### smooth by median value, n frames 
     for frame, xy in cache.items():

--- a/src/openpose_3dpose_sandbox_realtime.py
+++ b/src/openpose_3dpose_sandbox_realtime.py
@@ -74,7 +74,7 @@ def main(_):
                     xy.append(_data[o+1])
 
                 frame_indx = re.findall("(\d+)", file_name)
-                frame = int(frame_indx[0])
+                frame = int(frame_indx[-1])
                 logger.debug("found {0} for frame {1}".format(xy, str(frame)))
 
                 #body_25 support, convert body_25 output format to coco


### PR DESCRIPTION
re.findall followed by indexing by 0 was resulting in the wrong frame_indx for keypoint files obtained from videos with digits e.g. '001m_ang_2.6_win_1_000000000000_keypoints.json'.

Have modified to take the last match.